### PR TITLE
Move narrow component to header and remove navigation

### DIFF
--- a/public/onevision-encoder/index.html
+++ b/public/onevision-encoder/index.html
@@ -80,6 +80,41 @@
             color: #0f172a;
         }
 
+        /* Header Buttons - Compact style for navigation */
+        .btn-header {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-weight: 500;
+            font-size: 0.8rem;
+            transition: all 0.2s ease;
+            border: 1px solid transparent;
+        }
+        .btn-header-primary {
+            background-color: #4b5563;
+            color: white;
+        }
+        .btn-header-accent {
+            background-color: #f8fafc;
+            color: #0f172a;
+            border-color: #e2e8f0;
+        }
+        .btn-header-accent:hover {
+            background-color: #f1f5f9;
+            border-color: #cbd5e1;
+        }
+        .btn-header-secondary {
+            background-color: transparent;
+            color: #475569;
+            border-color: #e2e8f0;
+        }
+        .btn-header-secondary:hover {
+            background-color: #f8fafc;
+            color: #0f172a;
+        }
+
         /* Feature Cards - Cleaner with minimal shadows */
         .feature-card {
             background-color: transparent;
@@ -449,13 +484,21 @@
                 </div>
                 <!-- Desktop Navigation -->
                 <div class="hidden md:block">
-                    <div class="ml-10 flex items-center space-x-10">
-                        <a href="#abstract" class="nav-link">Introduction</a>
-                        <a href="#method" class="nav-link">Method</a>
-                        <a href="#results" class="nav-link">Results</a>
-                        <a href="#bibtex" class="nav-link">BibTeX</a>
-                        <a href="https://lmms-lab.com" class="btn btn-secondary text-sm py-1.5 px-3">
-                            <i class="fa-solid fa-arrow-left text-xs"></i> LMMs-Lab
+                    <div class="ml-10 flex items-center space-x-2">
+                        <span class="btn-header btn-header-primary opacity-60 cursor-not-allowed" title="Coming soon">
+                            <i class="fa-solid fa-file-pdf"></i> Paper
+                        </span>
+                        <a href="https://github.com/EvolvingLMMs-Lab/OneVision-Encoder" class="btn-header btn-header-accent">
+                            <i class="fa-brands fa-github"></i> Code
+                        </a>
+                        <a href="https://github.com/EvolvingLMMs-Lab/LLaVA-ViT" class="btn-header btn-header-secondary">
+                            <i class="fa-solid fa-layer-group"></i> Data
+                        </a>
+                        <a href="https://huggingface.co/lmms-lab-encoder/onevision-encoder-large" class="btn-header btn-header-secondary">
+                            <i class="fa-solid fa-database"></i> Models
+                        </a>
+                        <a href="https://lmms-lab.com" class="btn-header btn-header-secondary">
+                            <i class="fa-solid fa-arrow-left"></i> LMMs-Lab
                         </a>
                     </div>
                 </div>
@@ -467,10 +510,21 @@
         </div>
         <!-- Mobile Navigation Menu -->
         <div class="mobile-nav md:hidden" id="mobileMenu">
-            <a href="#abstract" class="nav-link">Introduction</a>
-            <a href="#method" class="nav-link">Method</a>
-            <a href="#results" class="nav-link">Results</a>
-            <a href="#bibtex" class="nav-link">BibTeX</a>
+            <span class="nav-link opacity-60 cursor-not-allowed">
+                <i class="fa-solid fa-file-pdf mr-2"></i> Paper (Coming)
+            </span>
+            <a href="https://github.com/EvolvingLMMs-Lab/OneVision-Encoder" class="nav-link">
+                <i class="fa-brands fa-github mr-2"></i> Code
+            </a>
+            <a href="https://github.com/EvolvingLMMs-Lab/LLaVA-ViT" class="nav-link">
+                <i class="fa-solid fa-layer-group mr-2"></i> Data
+            </a>
+            <a href="https://huggingface.co/lmms-lab-encoder/onevision-encoder-large" class="nav-link">
+                <i class="fa-solid fa-database mr-2"></i> Models
+            </a>
+            <a href="https://lmms-lab.com" class="nav-link">
+                <i class="fa-solid fa-arrow-left mr-2"></i> LMMs-Lab
+            </a>
         </div>
     </nav>
 
@@ -486,22 +540,6 @@
 
             <div class="mt-8 text-base text-gray-500">
                 <p class="font-medium">LLaVA-OneVision Community Contributors</p>
-            </div>
-
-            <!-- Action Buttons -->
-            <div class="mt-12 flex justify-center gap-3 flex-wrap">
-                <span class="btn btn-primary opacity-60 cursor-not-allowed" title="Coming soon">
-                    <i class="fa-solid fa-file-pdf"></i> Paper (Coming) 
-                </span>
-                <a href="https://github.com/EvolvingLMMs-Lab/OneVision-Encoder" class="btn btn-accent">
-                    <i class="fa-brands fa-github"></i> Code
-                </a>
-                <a href="https://github.com/EvolvingLMMs-Lab/LLaVA-ViT" class="btn btn-secondary">
-                    <i class="fa-solid fa-layer-group"></i> Data (Coming) 
-                </a>
-                <a href="https://huggingface.co/lmms-lab-encoder/onevision-encoder-large" class="btn btn-secondary">
-                    <i class="fa-solid fa-database"></i> Models
-                </a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
- Move Paper/Code/Data/Models buttons from hero section to header
- Add compact btn-header styles for narrower header buttons
- Remove navigation text links (Introduction/Method/Results/BibTeX)
- Keep icon + text format for all action buttons
- Update mobile menu with the same action buttons